### PR TITLE
Rename »Bridge« to »Project« in empty state

### DIFF
--- a/resources/assets/js/components/BridgesEmptyState.js
+++ b/resources/assets/js/components/BridgesEmptyState.js
@@ -7,7 +7,7 @@ const BridgesEmptyState = () => {
             <div>
                 <img src="/images/tmp/empty_bridges.svg" width="500" />
             </div>
-            <Link className="button button-blue" to="/projects/new">Create Bridge</Link>
+            <Link className="button button-blue" to="/projects/new">Create Project</Link>
         </div>
     );
 };


### PR DESCRIPTION
It was still called »Bridge« in the empty state, so fixing according to https://github.com/uracreative/identihub/issues/7

Please review @elioqoshi @Borisbudini @AleksanderKoko 