### PR TITLE
Change wording from 'My Projects' to simpler 'Projects'

### DIFF
--- a/resources/assets/js/components/BridgesList.js
+++ b/resources/assets/js/components/BridgesList.js
@@ -11,7 +11,7 @@ class BridgesList extends Component{
 
       return (
           <div>
-              <h1>My Projects</h1>
+              <h1>Projects</h1>
               <CSSTransitionGroup
                   component="div"
                   className="bridge-list"


### PR DESCRIPTION
For consistency with the breadcrumb bar where it also only says »Projects«. Also, displaying »My« / »Your« in an interface is always a bit strange and should be avoided where possible – and here it absolutely can. :)

Please review @elioqoshi @Borisbudini 