### PR TITLE
Replace '>>' for breadcrumbs with proper forward icon

### DIFF
--- a/resources/assets/js/pages/Bridge.js
+++ b/resources/assets/js/pages/Bridge.js
@@ -86,12 +86,14 @@ export class Bridge extends Component {
 
         let breadCrumb = null;
         let plusIcon = null;
+        let forwardIcon = null;
         let tooltip = null;
 
         if (!isPub) {
+            forwardIcon = (<img src="/images/forward.svg" width="10" height="10"/>);
             breadCrumb = (
                 <div className="breadcrumb">
-                    <Link to="/projects">Projects</Link> {'>>'} <span>{bridge.name}</span>
+                    <Link to="/projects">Projects</Link> {forwardIcon} <span>{bridge.name}</span>
                 </div>
             );
         }


### PR DESCRIPTION
The icon was already there, just needed to be used. ;)

Before:
![screenshot from 2018-01-10 13-58-09](https://user-images.githubusercontent.com/925062/34774271-f92ac4ba-f60e-11e7-8a5c-078483330efe.png)

After:
![screenshot from 2018-01-10 13-57-37](https://user-images.githubusercontent.com/925062/34774272-f97338ee-f60e-11e7-9450-ed71cf13b98b.png)


Please review @elioqoshi @Borisbudini @chrispecoraro 