### PR TITLE
Added librsvg2-bin and php-imagick to the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Identihub is an open-source web platform for brand and assets management. It is 
 #### Installing the software
 ```bash
 apt-get update && apt-get upgrade
-apt-get install apache2 mysql-server php libapache2-mod-php php-mcrypt php-mysql php-curl php-json php-mbstring php-dom composer unzip libmagickwand-dev imagemagick php-dev
+apt-get install  apache2 mysql-server php libapache2-mod-php php-mcrypt php-mysql php-curl php-json php-mbstring php-xml composer unzip libmagickwand-dev imagemagick php-dev librsvg2-bin php-imagick
 ```
 #### Setting up the database
 ```bash


### PR DESCRIPTION
In the old documentation we were missing librsvg2-bin and php-imagick which would make it imposible to upload svg in identihub since there was no delegators between the front end and the back end