### PR TITLE
Add snapsvg cjs to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8523,6 +8523,22 @@
         "kind-of": "3.2.2"
       }
     },
+        "snapsvg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/snapsvg/-/snapsvg-0.5.1.tgz",
+      "integrity": "sha1-DK9Sx5GJopB0b8RGzF6GP2vd3+M=",
+      "requires": {
+        "eve": "0.5.4"
+      }
+    },
+    "snapsvg-cjs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/snapsvg-cjs/-/snapsvg-cjs-0.0.6.tgz",
+      "integrity": "sha1-Oy9WryVz09Nkw+1b+IhXRfTS3eE=",
+      "requires": {
+        "snapsvg": "0.5.1"
+      }
+    },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dnd": "^2.4.0",
     "react-dnd-html5-backend": "^2.4.1",
     "react-notification-system": "0.2.x",
-    "react-svg": "^2.1.21"
+    "react-svg": "^2.1.21",
+    "snapsvg-cjs": "0.0.6"
   }
 }


### PR DESCRIPTION
snapsvg-cjs is a dependency needed by react-burger-menu
Simpy added it to package files