### PR TITLE
Added validation request max(int|width) 20000px

### DIFF
--- a/app/Http/Requests/ConvertedStoreRequest.php
+++ b/app/Http/Requests/ConvertedStoreRequest.php
@@ -24,7 +24,8 @@ class ConvertedStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            //
+            'width' => 'required|integer|max:20000',
+            'height' => 'required|integer|max:20000'
         ];
     }
 }

--- a/app/Http/Requests/CreateConvertedIcon.php
+++ b/app/Http/Requests/CreateConvertedIcon.php
@@ -24,8 +24,8 @@ class CreateConvertedIcon extends FormRequest
     public function rules()
     {
         return [
-            'width' => 'required|integer',
-            'height' => 'required|integer'
+            'width' => 'required|integer|max:20000',
+            'height' => 'required|integer|max:20000'
         ];
     }
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-  "/js/react-panel.js": "/js/react-panel.23230179e338b932cc81.js",
-  "/css/app.css": "/css/app.a08a57be9e325d9adc66.css",
-  "/js/react-public.js": "/js/react-public.cd8f34433f985c372b4b.js"
+  "/js/react-panel.js": "/js/react-panel.bc9e2e3418ec57e846d9.js",
+  "/css/app.css": "/css/app.b537fc95cdc52a9f6303.css",
+  "/js/react-public.js": "/js/react-public.17b86c554a7854670fe6.js"
 }

--- a/resources/assets/js/reducers/Bridge/BridgeApiCalls.js
+++ b/resources/assets/js/reducers/Bridge/BridgeApiCalls.js
@@ -179,6 +179,8 @@ export function addIconConverted(bridgeId, iconId, width, height){
         dispatch(addBridge(response.data.bridge));
       })
       .catch(function(error) {
+        console.log('Something went wrong');
+        console.log(error.response.data);
         console.log(error);
       });
   }
@@ -191,6 +193,8 @@ export function addImageConverted(bridgeId, imageId, width, height){
         dispatch(addBridge(response.data.bridge));
       })
       .catch(function(error) {
+        console.log('Something went wrong');
+        console.log(error.response.data);
         console.log(error);
       });
   }


### PR DESCRIPTION
Issue #96 
Added max height|width validation of 20000px as suggested by @elioqoshi 

I tackled the backend only issue since this would have to be paired with some feedback on the front-end side.
I modified both the addIconConverted and addImageConverted on the react codebase to fetch the validation errors coming from the server. Somehow now this has to be sent to ui