### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 [(Installation guides are located in our wiki)](https://github.com/uracreative/identihub/wiki/Installation-Guide) 
 
 There are are several ways to install Identihub in various configurations
-* [From source](https://github.com/uracreative/identihub/wiki/Installation-Guide-%28from-souce%29)
+* [From source](https://github.com/uracreative/identihub/wiki/Installation-Guide-%28from-source%29)
 * [Homestead](https://github.com/uracreative/identihub/wiki/Installation-guide-(homestead))
 
 


### PR DESCRIPTION
Typo link for source install docs fixed. This should also be fixed in https://github.com/uracreative/identihub/wiki/Installation-Guide but I dont have rights to edit that.